### PR TITLE
don't explode when no exc_info is available, fixes flask logging

### DIFF
--- a/slacker_log_handler/__init__.py
+++ b/slacker_log_handler/__init__.py
@@ -30,11 +30,13 @@ class SlackerLogHandler(Handler):
 
     def emit(self, record):
         message = str(record.getMessage())
-        attachments = [{
+        trace = {
             'fallback': message,
-            'color': COLORS.get(self.level, INFO_COLOR),
-            'text': '\n'.join(traceback.format_exception(*record.exc_info))
-        }]
+            'color': COLORS.get(self.level, INFO_COLOR)
+        }
+        if record.exc_info:
+            trace['text'] = '\n'.join(traceback.format_exception(*record.exc_info))
+        attachments = [trace]
         self.slack_chat.chat.post_message(
             text=message,
             channel=self.channel,


### PR DESCRIPTION
Fixes the following use case on flask (tested with python 3.5):

``` python
if not app.debug:
    print("adding slack logging")
    handler = slh.SlackerLogHandler(apy_key, channel, username="Python errors")
    handler.setLevel(logging.ERROR)
    app.logger.addHandler(handler)

app.logger.error("this error goes to slack")
```
