### PR TITLE
Use formatter to build message. Default behavior unchanged.

### DIFF
--- a/slacker_log_handler/__init__.py
+++ b/slacker_log_handler/__init__.py
@@ -38,7 +38,7 @@ class SlackerLogHandler(Handler):
             self.channel = '#' + self.channel
 
     def build_msg(self, record):
-        return six.text_type(record.getMessage())
+        return six.text_type(self.format(record))
 
     def build_trace(self, record, fallback):
         trace = {


### PR DESCRIPTION
From python example:

```python
import logging
from slacker_log_handler import SlackerLogHandler

# Create slack handler
slack_handler = SlackerLogHandler('my-channel-token', 'my-channel-name')
slack_handler.setLevel(logging.DEBUG)

# Create logger
logger = logging.getLogger('debug_application')
logger.addHandler(slack_handler) 

# No Formatter
logger.error("Debug message from slack!")
>>> "Debug message from slack!"

# Add Formatter
formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
slack_handler.setFormatter(formatter)
logger.error("Debug message from slack!")
>>> "2017-07-06 14:12:51,282 - debug_application - ERROR - Debug message from slack!"

```